### PR TITLE
fix WebRequestEvent events capture to avoid crashing because No match…

### DIFF
--- a/__fixtures__/extensions/basic/content.js
+++ b/__fixtures__/extensions/basic/content.js
@@ -4,4 +4,5 @@ console.log(x)
 
 console.log('content.js')
 
+
 chrome.contextMenus.removeAll()

--- a/src/manifest-input/__tests__/manifest__hook--generateBundle.test.ts
+++ b/src/manifest-input/__tests__/manifest__hook--generateBundle.test.ts
@@ -72,7 +72,9 @@ test('derives permissions from chunks', async () => {
   expect(manifest.permissions).toContain('contextMenus')
   expect(manifest.permissions).toContain('bookmarks')
   expect(manifest.permissions).toContain('cookies')
-  expect(manifest.permissions!.length).toBe(4)
+  expect(manifest.permissions).toContain('webRequest')
+  expect(manifest.permissions).toContain('webRequestBlocking')
+  expect(manifest.permissions!.length).toBe(6)
 })
 
 test('does not warn permissions for verbose false', async () => {

--- a/src/manifest-input/browser/captureEvents.ts
+++ b/src/manifest-input/browser/captureEvents.ts
@@ -11,7 +11,9 @@ export function captureEvents(events: ChromeEvent[]) {
     const callbacks = new Map<Function, any[]>()
     const events = new Set<any[]>()
 
-    event.addListener(handleEvent)
+    if (event.constructor.name !== 'WebRequestEvent') {
+      event.addListener(handleEvent)
+    }
 
     function handleEvent(...args: any[]) {
       const error = chrome.runtime.lastError


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: #44

### Description

The PR add an ignore for event capturing for WebRequestEvents according to issue #44 
I couldn't find a way to test the app rendering in chrome so I just added tests that ensure the manifest ebbed the correct permissions if the code refer to webRequests event listening.

