### PR TITLE
[fix] output correctly named chunks

### DIFF
--- a/__fixtures__/extensions/chunk-file-names/background/background.js
+++ b/__fixtures__/extensions/chunk-file-names/background/background.js
@@ -1,0 +1,7 @@
+import { x } from '../shared/imported'
+
+console.log(x)
+
+console.log('background.js')
+
+chrome.storage.local.clear()

--- a/__fixtures__/extensions/chunk-file-names/content/content.js
+++ b/__fixtures__/extensions/chunk-file-names/content/content.js
@@ -1,0 +1,7 @@
+import { x } from '../shared/imported'
+
+console.log(x)
+
+console.log('content.js')
+
+chrome.contextMenus.removeAll()

--- a/__fixtures__/extensions/chunk-file-names/manifest.json
+++ b/__fixtures__/extensions/chunk-file-names/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "chunk-file-names",
+  "description": "rollup option chunkFileNames in subfolder",
+  "manifest_version": 2,
+  "version": "1.0.0",
+  "background": {
+    "scripts": ["background/background.js"]
+  },
+  "content_scripts": [
+    {
+      "js": ["content/content.js"],
+      "matches": ["https://www.google.com/*"]
+    }
+  ]
+}

--- a/__fixtures__/extensions/chunk-file-names/rollup.config.js
+++ b/__fixtures__/extensions/chunk-file-names/rollup.config.js
@@ -1,0 +1,19 @@
+import { basename } from 'path'
+import commonjs from '@rollup/plugin-commonjs'
+import resolve from '@rollup/plugin-node-resolve'
+import { chromeExtension } from '../../../src/index'
+import { getExtPath } from '../../utils'
+
+export default {
+  input: getExtPath(basename(__dirname) + '/manifest.json'),
+  output: {
+    dir: getExtPath(basename(__dirname) + '-dist'),
+    format: 'esm',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+  },
+  plugins: [
+    chromeExtension({ verbose: false }),
+    resolve(),
+    commonjs(),
+  ],
+}

--- a/__fixtures__/extensions/chunk-file-names/shared/imported.js
+++ b/__fixtures__/extensions/chunk-file-names/shared/imported.js
@@ -1,0 +1,1 @@
+export const x = 'x'

--- a/__tests__/e2e__chunk-file-names.test.ts
+++ b/__tests__/e2e__chunk-file-names.test.ts
@@ -1,0 +1,58 @@
+import path from 'path'
+import { rollup, RollupOptions, RollupOutput } from 'rollup'
+import { isAsset, isChunk } from '../src/helpers'
+import { ChromeExtensionManifest } from '../src/manifest'
+import { deriveFiles } from '../src/manifest-input/manifest-parser'
+import { byFileName, getExtPath, getTestName, requireExtFile } from '../__fixtures__/utils'
+
+const testName = getTestName(__filename)
+const extPath = getExtPath(testName)
+
+let outputPromise: Promise<RollupOutput>
+beforeAll(async () => {
+  const config = requireExtFile<RollupOptions>(__filename, 'rollup.config.js')
+  outputPromise = rollup(config).then((bundle) => bundle.generate(config.output as any))
+  return outputPromise
+}, 15000)
+
+test('bundles chunks and assets', async () => {
+  const { output } = await outputPromise
+
+  // Chunks
+  const chunks = output.filter(isChunk)
+  expect(chunks.length).toBe(3)
+  // 2 chunks + one shared import (imported.js)
+  expect(chunks.find(byFileName('background/background.js'))).toBeDefined()
+  expect(chunks.find(byFileName('content/content.js'))).toBeDefined()
+
+  const imported = chunks.find(({ fileName }) => fileName.includes('imported'))
+  // Chunk should be in correct folder and not be double hashed
+  expect(imported?.fileName).toMatch(/^chunks\/imported-[a-z1-9]+?\.js$/)
+})
+
+test('bundles assets', async () => {
+  const { output } = await outputPromise
+
+  // Assets
+  const assets = output.filter(isAsset)
+  expect(assets.length).toBe(3)
+  // 2 dynamic import wrappers and the manifest
+  const manifestJson = assets.find(byFileName('manifest.json'))
+  expect(manifestJson).toBeDefined()
+})
+
+test('chunks in output match chunks in manifest', async () => {
+  const { output } = await outputPromise
+
+  const assets = output.filter(isAsset)
+  const manifestJson = assets.find(byFileName('manifest.json'))!
+  const manifest = JSON.parse(manifestJson.source as string) as ChromeExtensionManifest
+
+  // Get scripts in manifest
+  const { js } = deriveFiles(manifest, extPath)
+
+  js.map((x) => path.relative(extPath, x)).forEach((script) => {
+    const chunk = output.find(byFileName(script))
+    expect(chunk).toBeDefined()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ export const chromeExtension = (
       await manifest.generateBundle.call(this, ...args)
       await validate.generateBundle.call(this, ...args)
       await browser.generateBundle.call(this, ...args)
+      // TODO: should skip this if not needed
       await mixedFormat.generateBundle.call(this, ...args)
     },
   }

--- a/src/mixed-format/index.ts
+++ b/src/mixed-format/index.ts
@@ -16,7 +16,7 @@ export function mixedFormat(
     name: 'mixed-format',
     async generateBundle(
       this: PluginContext,
-      { format }: OutputOptions,
+      { format, chunkFileNames }: OutputOptions,
       bundle: OutputBundle,
     ): Promise<void> {
       const { formatMap } = options // this might not be defined upon init
@@ -60,6 +60,7 @@ export function mixedFormat(
                 input,
                 output: {
                   format: f,
+                  chunkFileNames,
                 },
               },
               bundle,
@@ -75,7 +76,7 @@ export function mixedFormat(
           input: Object.entries(bundle)
             .filter(([, file]) => isChunk(file) && file.isEntry)
             .map(([key]) => key),
-          output: { format },
+          output: { format, chunkFileNames },
         },
         bundle,
       )

--- a/src/mixed-format/regenerateBundle.ts
+++ b/src/mixed-format/regenerateBundle.ts
@@ -31,8 +31,11 @@ export async function regenerateBundle(
     return {}
   }
 
-  const { format } = output
+  const { format, chunkFileNames: cfn = '' } = output
+  
+  const chunkFileNames = path.join(path.dirname(cfn), '[name].js')
 
+  // Transform input array to input object
   const inputValue = Array.isArray(input)
     ? input.reduce((r, x) => {
         const { dir, name } = path.parse(x)
@@ -48,6 +51,7 @@ export async function regenerateBundle(
   let _b: OutputBundle
   await build.generate({
     format,
+    chunkFileNames,
     plugins: [
       {
         name: 'get-bundle',


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: #60

### Description

PR #53 broke chunk file names for non-entry modules, removing subfolders and adding double hashes to output files. The manifest retains the expected file names, but the files are named incorrectly.

This PR adds tests to ensure that every file in the manifest is correctly named in the output bundle.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
