### PR TITLE
fix: jsx & tsx not converted

### DIFF
--- a/src/manifest-input/index.ts
+++ b/src/manifest-input/index.ts
@@ -403,7 +403,7 @@ export function manifestInput(
                 ? rest
                 : {
                     js: js
-                      .map((p) => p.replace(/\.ts$/, '.js'))
+                      .map((p) => p.replace(/\.[jt]sx?/g, '.js'))
                       .map(memoizedEmitter),
                     ...rest,
                   }
@@ -439,7 +439,7 @@ export function manifestInput(
           // background exists because bgs has scripts
           manifestBody.background!.scripts = bgs
             // SMELL: is this replace necessary? are we doing somewhere else?
-            .map((p) => p.replace(/\.ts$/, '.js'))
+            .map((p) => p.replace(/\.[jt]sx?/g, '.js'))
             .map((scriptPath: string) => {
               // Loader script exists because of type guard above
               const source =


### PR DESCRIPTION
When assets is generated, jsx & tsx file path not converted

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)

Breaking Changes?

- [x] no

List any relevant issue numbers:

### Description

There should be a better solution. This solution is based on the current code.
