### PR TITLE
Pass output.sourcemap option through to (re)generateBundle. Fixes #69

### DIFF
--- a/__fixtures__/extensions/basic-ts/rollup.config.js
+++ b/__fixtures__/extensions/basic-ts/rollup.config.js
@@ -33,6 +33,7 @@ export default {
     dir: getExtPath(`${crxName}-dist`),
     format: 'esm',
     chunkFileNames: 'chunks/[name]-[hash].js',
+    sourcemap: 'inline',
   },
   plugins: [
     chromeExtension(),

--- a/__tests__/e2e__basic-ts.test.ts
+++ b/__tests__/e2e__basic-ts.test.ts
@@ -53,5 +53,8 @@ test('chunks in output match chunks in manifest', async () => {
   js.map((x) => path.relative(extPath, x)).forEach((script) => {
     const chunk = output.find(byFileName(script))
     expect(chunk).toBeDefined()
+    if (chunk?.type === 'chunk') {
+      expect(typeof chunk?.map?.toUrl()).toBe('string')
+    }
   })
 })

--- a/src/mixed-format/index.ts
+++ b/src/mixed-format/index.ts
@@ -16,7 +16,7 @@ export function mixedFormat(
     name: 'mixed-format',
     async generateBundle(
       this: PluginContext,
-      { format, chunkFileNames }: OutputOptions,
+      { format, chunkFileNames, sourcemap }: OutputOptions,
       bundle: OutputBundle,
     ): Promise<void> {
       const { formatMap } = options // this might not be defined upon init
@@ -61,6 +61,7 @@ export function mixedFormat(
                 output: {
                   format: f,
                   chunkFileNames,
+                  sourcemap,
                 },
               },
               bundle,
@@ -76,7 +77,7 @@ export function mixedFormat(
           input: Object.entries(bundle)
             .filter(([, file]) => isChunk(file) && file.isEntry)
             .map(([key]) => key),
-          output: { format, chunkFileNames },
+          output: { format, chunkFileNames, sourcemap },
         },
         bundle,
       )

--- a/src/mixed-format/regenerateBundle.ts
+++ b/src/mixed-format/regenerateBundle.ts
@@ -31,7 +31,7 @@ export async function regenerateBundle(
     return {}
   }
 
-  const { format, chunkFileNames: cfn = '' } = output
+  const { format, chunkFileNames: cfn = '', sourcemap } = output
   
   const chunkFileNames = path.join(path.dirname(cfn), '[name].js')
 
@@ -51,6 +51,7 @@ export async function regenerateBundle(
   let _b: OutputBundle
   await build.generate({
     format,
+    sourcemap,
     chunkFileNames,
     plugins: [
       {


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: Fixes #69 

### Description

Source maps stopped working since 3.5.x as the sourcemap output option was no longer passed through to rollup.
