### PR TITLE
Fix manifest file paths for Windows

### DIFF
--- a/__fixtures__/plugin-context.ts
+++ b/__fixtures__/plugin-context.ts
@@ -71,7 +71,7 @@ export const context: MockPluginContext = {
   /** @deprecated Use `this.getFileName` instead */
   // @ts-ignore
   getChunkFileName: null,
-  getFileName: jest.fn(),
+  getFileName: jest.fn((id) => `sample/file-path-${id}.js`),
   getModuleInfo: jest.fn(),
   /** @deprecated Use `this.resolve` instead */
   // @ts-ignore

--- a/src/manifest-input/__tests__/manifest__hook--generateBundle.test.ts
+++ b/src/manifest-input/__tests__/manifest__hook--generateBundle.test.ts
@@ -314,3 +314,77 @@ test('Throws if cache.manifest is falsey', async () => {
     expect(error).toEqual(new TypeError(errorMessage))
   }
 })
+
+test('emits correct paths on Windows', async () => {
+  context.getFileName.mockImplementation(
+    (id) => `sample\\file-path-${id}.js`,
+  )
+
+  const bundle = cloneObject(await bundlePromise)
+
+  await plugin.generateBundle.call(
+    context,
+    options,
+    bundle,
+    false,
+  )
+
+  expect(context.emitFile).toBeCalledWith<[EmittedFile]>({
+    type: 'asset',
+    fileName: 'manifest.json',
+    source: JSON.stringify(
+      {
+        manifest_version: 2,
+        name: 'kitchen-sink',
+        version: '1.0.0',
+        description: 'kitchen-sink chrome extension',
+        icons: {
+          '16': 'images/icon-main-16.png',
+          '48': 'images/icon-main-48.png',
+          '128': 'images/icon-main-128.png',
+        },
+        devtools_page: 'devtools/devtools.html',
+        background: {
+          scripts: ['sample/file-path-background.js.js'],
+        },
+        permissions: [
+          'storage',
+          'contextMenus',
+          'bookmarks',
+          'cookies',
+          'webRequest',
+          'webRequestBlocking',
+        ],
+        content_scripts: [
+          {
+            js: ['sample/file-path-content.js.js'],
+            matches: ['https://www.google.com/*'],
+          },
+          {
+            js: ['sample/file-path-content.js.js'],
+            css: ['content.css'],
+            matches: ['https://www.yahoo.com/*'],
+          },
+        ],
+        options_page: 'options.html',
+        browser_action: {
+          default_icon: {
+            '16': 'images/icon-main-16.png',
+          },
+          default_popup: 'popup/popup.html',
+        },
+        web_accessible_resources: [
+          'options.jpg',
+          'fonts/*.ttf',
+          'fonts/*.otf',
+          'imported-c14c3b91.js',
+          'content.js',
+        ],
+        content_security_policy:
+          "script-src 'self'; object-src 'self'",
+      },
+      undefined,
+      2,
+    ),
+  })
+})

--- a/src/manifest-input/index.ts
+++ b/src/manifest-input/index.ts
@@ -408,7 +408,8 @@ export function manifestInput(
                 : {
                     js: js
                       .map(normalizeFilename)
-                      .map(memoizedEmitter),
+                      .map(memoizedEmitter)
+                      .map((p) => slash(p)),
                     ...rest,
                   }
             },
@@ -431,7 +432,7 @@ export function manifestInput(
             ...imports,
             // Need to be web accessible b/c of import
             ...contentScripts,
-          ])
+          ]).map((p) => slash(p))
         }
 
         /* ----------- END SETUP CONTENT SCRIPTS ----------- */
@@ -463,6 +464,7 @@ export function manifestInput(
 
               return this.getFileName(assetId)
             })
+            .map((p) => slash(p))
         }
 
         /* ---------- END SETUP BACKGROUND SCRIPTS --------- */


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: https://github.com/extend-chrome/js-react-boilerplate/issues/2

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

RPCE outputs possibly invalid file paths in the manifest on Windows due to the way the `path` module behaves on Windows.

```
const path = require('path');

const string = path.join('foo', 'bar');
// Unix    => foo/bar
// Windows => foo\\bar
```

This PR maps all script paths through through [`slash`](https://www.npmjs.com/package/slash) to fix this.
