### PR TITLE
Don't call `Object.keys` on `null` in `getDeepMatches`

### DIFF
--- a/src/manifest-input/browser/getDeepMatches.test.ts
+++ b/src/manifest-input/browser/getDeepMatches.test.ts
@@ -1,0 +1,17 @@
+import { getDeepMatches } from './getDeepMatches'
+
+test("null keys don't cause an exception to be thrown when the predicate doesn't match", () => {
+  const obj = {
+    runtime: {
+      lastError: null,
+      onMessage: {
+        addListener() {},
+      },
+    },
+  }
+  expect(getDeepMatches(obj, (x) => typeof x === 'object' && 'addListener' in x, [])).toEqual([
+    {
+      addListener: obj.runtime.onMessage.addListener,
+    },
+  ])
+})

--- a/src/manifest-input/browser/getDeepMatches.ts
+++ b/src/manifest-input/browser/getDeepMatches.ts
@@ -9,7 +9,7 @@
  * @returns {T[]} The matched values from the parent object
  */
 export function getDeepMatches<T>(object: any, pred: (x: any) => boolean, excludeKeys: string[]): T[] {
-  const keys = typeof object === 'object' ? Object.keys(object) : []
+  const keys = typeof object === 'object' && object ? Object.keys(object) : []
 
   return keys.length
     ? keys


### PR DESCRIPTION
Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: #56 

### Description

`chrome.runtime.lastError` is `null` rather than `undefined`[1] in Firefox so the `getDeepMatches` caller in importWrapper--implicit.ts leads to an error being thrown.

This breaks the startup of my extension in Firefox.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1406674
