### PR TITLE
fix: delay reload by 100ms

### DIFF
--- a/src/plugin-reloader-simple/__tests__/simpleReloader__hook--writeBundle.test.ts
+++ b/src/plugin-reloader-simple/__tests__/simpleReloader__hook--writeBundle.test.ts
@@ -13,6 +13,9 @@ const timestampPath = 'timestampPath'
 
 const buildPromise = buildCRX()
 
+beforeAll(jest.useFakeTimers)
+afterEach(jest.clearAllMocks)
+
 beforeEach(() => {
   process.env.ROLLUP_WATCH = 'true'
 })
@@ -20,7 +23,7 @@ beforeEach(() => {
 test('Writes timestamp file', async () => {
   const { bundle } = cloneObject(await buildPromise)
   const plugin = simpleReloader(
-    {},
+    { reloadDelay: 0 },
     { outputDir, timestampPath },
   )!
 
@@ -32,10 +35,31 @@ test('Writes timestamp file', async () => {
   )
 })
 
+test('Delays prescribed amount', async () => {
+  const { bundle } = cloneObject(await buildPromise)
+  const plugin = simpleReloader(
+    { reloadDelay: 100 },
+    { outputDir, timestampPath },
+  )!
+
+  const promise = plugin.writeBundle.call(context, bundle)
+
+  expect(mockOutputJson).not.toBeCalled()
+
+  jest.advanceTimersToNextTimer()
+
+  await promise
+
+  expect(mockOutputJson).toBeCalledWith(
+    join(outputDir, timestampPath),
+    expect.any(Number),
+  )
+})
+
 test('Handles write errors with message prop', async () => {
   const { bundle } = cloneObject(await buildPromise)
   const plugin = simpleReloader(
-    {},
+    { reloadDelay: 0 },
     { outputDir, timestampPath },
   )!
 
@@ -58,7 +82,7 @@ test('Handles write errors with message prop', async () => {
 test('Handles other write errors', async () => {
   const { bundle } = cloneObject(await buildPromise)
   const plugin = simpleReloader(
-    {},
+    { reloadDelay: 0 },
     { outputDir, timestampPath },
   )!
 

--- a/src/plugin-reloader-simple/index.ts
+++ b/src/plugin-reloader-simple/index.ts
@@ -196,7 +196,7 @@ export const simpleReloader = (
     /* -------------- WRITE TIMESTAMP FILE ------------- */
     async writeBundle() {
       // Sometimes Chrome says the manifest isn't valid, so we need to wait a bit
-      await delay(reloadDelay)
+      reloadDelay > 0 && (await delay(reloadDelay))
 
       try {
         await outputJson(
@@ -204,10 +204,7 @@ export const simpleReloader = (
           Date.now(),
         )
       } catch (err) {
-        if (
-          err instanceof Error &&
-          typeof err.message === 'string'
-        ) {
+        if (isErrorLike(err)) {
           this.error(
             `Unable to update timestamp file:\n\t${err.message}`,
           )
@@ -217,4 +214,11 @@ export const simpleReloader = (
       }
     },
   }
+}
+
+interface ErrorLike {
+  message: string
+}
+function isErrorLike(x: unknown): x is ErrorLike {
+  return typeof x === 'object' && x !== null && 'message' in x
 }


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: #85 

### Description

The simple reloader is triggering a reload before or while files are being written. This PR adds a configurable delay:

```javascript
// wait 250ms to trigger reload
simpleReloader({ reloadDelay: 250 }) 

// default delay is 100ms
simpleReloader() 

// Set delay to 0 to reload synchronously
simpleReloader({ reloadDelay: 0 })
```

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
