### PR TITLE
Support locales

### DIFF
--- a/__fixtures__/extensions/mv2-kitchen-sink/_locales/en/messages.json
+++ b/__fixtures__/extensions/mv2-kitchen-sink/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "MV3 with everything",
+    "description": "Chrome extension name"
+  },
+  "extDescription": {
+    "message": "MV3 Chrome Extension with all the options.",
+    "description": "Chrome extension description"
+  }
+}

--- a/__fixtures__/extensions/mv2-kitchen-sink/_locales/es/messages.json
+++ b/__fixtures__/extensions/mv2-kitchen-sink/_locales/es/messages.json
@@ -1,0 +1,6 @@
+{
+  "extName": { "message": "MV3 con todo" },
+  "extDescription": {
+    "message": "MV3 Chrome Extension con todo los opciones"
+  }
+}

--- a/__fixtures__/extensions/mv2-kitchen-sink/manifest.json
+++ b/__fixtures__/extensions/mv2-kitchen-sink/manifest.json
@@ -8,6 +8,7 @@
     "48": "images/icon-main-48.png",
     "128": "images/icon-main-128.png"
   },
+  "default_locale": "en",
   "devtools_page": "devtools/devtools.html",
   "background": {
     "scripts": [

--- a/__fixtures__/extensions/mv2-locales/babel.config.json
+++ b/__fixtures__/extensions/mv2-locales/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "targets": { "chrome": 80 } }],
+    "@babel/preset-react"
+  ],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/__fixtures__/extensions/mv2-locales/rollup.config.js
+++ b/__fixtures__/extensions/mv2-locales/rollup.config.js
@@ -1,0 +1,38 @@
+import path from 'path'
+
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import babel from '@rollup/plugin-babel'
+
+import { getExtPath, getCrxName } from '../../utils'
+
+import { chromeExtension, simpleReloader } from '../../../src'
+
+const crxName = getCrxName(__filename)
+
+export default {
+  input: getExtPath(crxName, 'src', 'manifest.json'),
+  output: {
+    dir: getExtPath(crxName, 'dist'),
+    format: 'esm',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+  },
+  plugins: [
+    chromeExtension(),
+    // Adds a Chrome extension reloader during watch mode
+    simpleReloader(),
+    babel({
+      // Do not transpile dependencies
+      ignore: ['node_modules'],
+      babelHelpers: 'bundled',
+      configFile: path.resolve(__dirname, 'babel.config.json'),
+    }),
+    resolve(),
+    commonjs({
+      namedExports: {
+        react: Object.keys(require('react')),
+        'react-dom': Object.keys(require('react-dom')),
+      },
+    }),
+  ],
+}

--- a/__fixtures__/extensions/mv2-locales/src/_locales/en/messages.json
+++ b/__fixtures__/extensions/mv2-locales/src/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "MV3 with everything",
+    "description": "Chrome extension name"
+  },
+  "extDescription": {
+    "message": "MV3 Chrome Extension with all the options.",
+    "description": "Chrome extension description"
+  }
+}

--- a/__fixtures__/extensions/mv2-locales/src/_locales/es/messages.json
+++ b/__fixtures__/extensions/mv2-locales/src/_locales/es/messages.json
@@ -1,0 +1,6 @@
+{
+  "extName": { "message": "MV3 con todo" },
+  "extDescription": {
+    "message": "MV3 Chrome Extension con todo los opciones"
+  }
+}

--- a/__fixtures__/extensions/mv2-locales/src/background.js
+++ b/__fixtures__/extensions/mv2-locales/src/background.js
@@ -1,0 +1,1 @@
+console.log('background script')

--- a/__fixtures__/extensions/mv2-locales/src/manifest.json
+++ b/__fixtures__/extensions/mv2-locales/src/manifest.json
@@ -1,0 +1,4 @@
+{
+  "background": { "scripts": ["background/index.js"] },
+  "default_locale": "en"
+}

--- a/__fixtures__/extensions/mv3-kitchen-sink/_locales/en/messages.json
+++ b/__fixtures__/extensions/mv3-kitchen-sink/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "MV3 with everything",
+    "description": "Chrome extension name"
+  },
+  "extDescription": {
+    "message": "MV3 Chrome Extension with all the options.",
+    "description": "Chrome extension description"
+  }
+}

--- a/__fixtures__/extensions/mv3-kitchen-sink/_locales/es/messages.json
+++ b/__fixtures__/extensions/mv3-kitchen-sink/_locales/es/messages.json
@@ -1,0 +1,6 @@
+{
+  "extName": { "message": "MV3 con todo" },
+  "extDescription": {
+    "message": "MV3 Chrome Extension con todo los opciones"
+  }
+}

--- a/__fixtures__/extensions/mv3-kitchen-sink/manifest.json
+++ b/__fixtures__/extensions/mv3-kitchen-sink/manifest.json
@@ -22,6 +22,7 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
+  "default_locale": "en",
   "description": "mv2-kitchen-sink chrome extension",
   "devtools_page": "devtools/devtools.html",
   "icons": {
@@ -30,7 +31,7 @@
     "128": "images/icon-main-128.png"
   },
   "manifest_version": 3,
-  "name": "mv2-kitchen-sink",
+  "name": "__MSG_extName__",
   "options_page": "options.html",
   "permissions": ["webRequest", "webRequestBlocking"],
   "version": "1.0.0",

--- a/__fixtures__/extensions/mv3-locales/babel.config.json
+++ b/__fixtures__/extensions/mv3-locales/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "targets": { "chrome": 80 } }],
+    "@babel/preset-react"
+  ],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/__fixtures__/extensions/mv3-locales/rollup.config.js
+++ b/__fixtures__/extensions/mv3-locales/rollup.config.js
@@ -1,0 +1,38 @@
+import path from 'path'
+
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import babel from '@rollup/plugin-babel'
+
+import { getExtPath, getCrxName } from '../../utils'
+
+import { chromeExtension, simpleReloader } from '../../../src'
+
+const crxName = getCrxName(__filename)
+
+export default {
+  input: getExtPath(crxName, 'src', 'manifest.json'),
+  output: {
+    dir: getExtPath(crxName, 'dist'),
+    format: 'esm',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+  },
+  plugins: [
+    chromeExtension(),
+    // Adds a Chrome extension reloader during watch mode
+    simpleReloader(),
+    babel({
+      // Do not transpile dependencies
+      ignore: ['node_modules'],
+      babelHelpers: 'bundled',
+      configFile: path.resolve(__dirname, 'babel.config.json'),
+    }),
+    resolve(),
+    commonjs({
+      namedExports: {
+        react: Object.keys(require('react')),
+        'react-dom': Object.keys(require('react-dom')),
+      },
+    }),
+  ],
+}

--- a/__fixtures__/extensions/mv3-locales/src/_locales/en/messages.json
+++ b/__fixtures__/extensions/mv3-locales/src/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "MV3 with everything",
+    "description": "Chrome extension name"
+  },
+  "extDescription": {
+    "message": "MV3 Chrome Extension with all the options.",
+    "description": "Chrome extension description"
+  }
+}

--- a/__fixtures__/extensions/mv3-locales/src/_locales/es/messages.json
+++ b/__fixtures__/extensions/mv3-locales/src/_locales/es/messages.json
@@ -1,0 +1,6 @@
+{
+  "extName": { "message": "MV3 con todo" },
+  "extDescription": {
+    "message": "MV3 Chrome Extension con todo los opciones"
+  }
+}

--- a/__fixtures__/extensions/mv3-locales/src/manifest.json
+++ b/__fixtures__/extensions/mv3-locales/src/manifest.json
@@ -1,0 +1,5 @@
+{
+  "background": { "service_worker": "service-worker.js" },
+  "default_locale": "en",
+  "manifest_version": 3
+}

--- a/__fixtures__/extensions/mv3-locales/src/service_worker.js
+++ b/__fixtures__/extensions/mv3-locales/src/service_worker.js
@@ -1,0 +1,1 @@
+console.log('service_worker.js')

--- a/__fixtures__/mv2-kitchen-sink-paths.ts
+++ b/__fixtures__/mv2-kitchen-sink-paths.ts
@@ -70,3 +70,16 @@ export const devtoolsHtml = getExtPath(
   crxName,
   'devtools/devtools.html',
 )
+
+// Locales subfolder
+export const localesEnJson = getExtPath(
+  crxName,
+  '_locales/en/messages.json',
+)
+export const localesEsJson = getExtPath(
+  crxName,
+  '_locales/en/messages.json',
+)
+
+// Double underscore bug
+export const _textFile = getExtPath(crxName, '_war/test.txt')

--- a/__fixtures__/mv3-kitchen-sink-paths.ts
+++ b/__fixtures__/mv3-kitchen-sink-paths.ts
@@ -73,3 +73,13 @@ export const devtoolsHtml = getExtPath(
   crxName,
   'devtools/devtools.html',
 )
+
+// Locales subfolder
+export const localesEnJson = getExtPath(
+  crxName,
+  '_locales/en/messages.json',
+)
+export const localesEsJson = getExtPath(
+  crxName,
+  '_locales/en/messages.json',
+)

--- a/__tests__/e2e__mv2-kitchen-sink.test.ts
+++ b/__tests__/e2e__mv2-kitchen-sink.test.ts
@@ -43,7 +43,7 @@ test('bundles assets', async () => {
 
   // Assets
   const assets = output.filter(isAsset)
-  expect(assets.length).toBe(19)
+  expect(assets.length).toBe(21)
 
   // 17 assets + 2 wrapper scripts
   expect(output.find(byFileName('asset.js'))).toBeDefined()
@@ -64,6 +64,9 @@ test('bundles assets', async () => {
   expect(output.find(byFileName('fonts/NotoSans-Light.ttf'))).toBeDefined()
   expect(output.find(byFileName('fonts/NotoSans-Black.ttf'))).toBeDefined()
   expect(output.find(byFileName('fonts/Missaali-Regular.otf'))).toBeDefined()
+
+  expect(output.find(byFileName('_locales/en/messages.json'))).toBeDefined()
+  expect(output.find(byFileName('_locales/es/messages.json'))).toBeDefined()
 })
 
 test('Includes content script imports in web_accessible_resources', async () => {

--- a/src/manifest-input/__tests__/manifest__hook--buildStart.test.ts
+++ b/src/manifest-input/__tests__/manifest__hook--buildStart.test.ts
@@ -11,6 +11,8 @@ import {
   missaaliOtf,
   notoSansLight,
   notoSansBlack,
+  localesEnJson,
+  localesEsJson,
 } from '../../../__fixtures__/mv2-kitchen-sink-paths'
 import { context as minContext } from '../../../__fixtures__/minimal-plugin-context'
 import { context } from '../../../__fixtures__/plugin-context'
@@ -49,7 +51,7 @@ jest.spyOn(fs, 'readFile')
 test('calls this.addWatchFile for manifest and assets', async () => {
   await plugin.buildStart.call(context, options)
 
-  expect(context.addWatchFile).toBeCalledTimes(9)
+  expect(context.addWatchFile).toBeCalledTimes(11)
   expect(context.addWatchFile).toBeCalledWith(manifestJson)
   expect(context.addWatchFile).toBeCalledWith(optionsJpg)
   expect(context.addWatchFile).toBeCalledWith(icon16)
@@ -59,12 +61,15 @@ test('calls this.addWatchFile for manifest and assets', async () => {
   expect(context.addWatchFile).toBeCalledWith(missaaliOtf)
   expect(context.addWatchFile).toBeCalledWith(notoSansBlack)
   expect(context.addWatchFile).toBeCalledWith(notoSansLight)
+  expect(context.addWatchFile).toBeCalledWith(notoSansLight)
+  expect(context.addWatchFile).toBeCalledWith(localesEnJson)
+  expect(context.addWatchFile).toBeCalledWith(localesEsJson)
 })
 
 test('calls readFile for assets', async () => {
   await plugin.buildStart.call(context, options)
 
-  expect(fs.readFile).toBeCalledTimes(8)
+  expect(fs.readFile).toBeCalledTimes(10)
   expect(fs.readFile).toBeCalledWith(optionsJpg)
   expect(fs.readFile).toBeCalledWith(icon16)
   expect(fs.readFile).toBeCalledWith(icon48)
@@ -73,6 +78,8 @@ test('calls readFile for assets', async () => {
   expect(fs.readFile).toBeCalledWith(missaaliOtf)
   expect(fs.readFile).toBeCalledWith(notoSansBlack)
   expect(fs.readFile).toBeCalledWith(notoSansLight)
+  expect(fs.readFile).toBeCalledWith(localesEnJson)
+  expect(fs.readFile).toBeCalledWith(localesEsJson)
 })
 
 test('readFile is memoized', async () => {
@@ -98,7 +105,7 @@ test('readFile only re-runs for changed files', async () => {
 test('emits each asset asset once', async () => {
   await plugin.buildStart.call(context, options)
 
-  expect(context.emitFile).toBeCalledTimes(8)
+  expect(context.emitFile).toBeCalledTimes(10)
   expect(context.emitFile).toBeCalledWith({
     type: 'asset',
     source: expect.any(Buffer),
@@ -140,6 +147,20 @@ test('emits each asset asset once', async () => {
     type: 'asset',
     source: expect.any(Buffer),
     fileName: notoSansBlack
+      .replace(srcDir, '')
+      .replace(/^\//, ''),
+  })
+  expect(context.emitFile).toBeCalledWith({
+    type: 'asset',
+    source: expect.any(Buffer),
+    fileName: localesEnJson
+      .replace(srcDir, '')
+      .replace(/^\//, ''),
+  })
+  expect(context.emitFile).toBeCalledWith({
+    type: 'asset',
+    source: expect.any(Buffer),
+    fileName: localesEsJson
       .replace(srcDir, '')
       .replace(/^\//, ''),
   })

--- a/src/manifest-input/__tests__/manifest__hook--generateBundle.test.ts
+++ b/src/manifest-input/__tests__/manifest__hook--generateBundle.test.ts
@@ -187,17 +187,31 @@ test('emits dynamic import wrappers once per file', async () => {
 
   expect(context.emitFile).toBeCalledWith<[EmittedFile]>({
     type: 'asset',
-    fileName: 'manifest.json',
-    source: expect.any(String),
-  })
-  expect(context.emitFile).toBeCalledWith<[EmittedFile]>({
-    type: 'asset',
     name: 'background.js',
     source: expect.any(String),
   })
   expect(context.emitFile).toBeCalledWith<[EmittedFile]>({
     type: 'asset',
     name: 'content.js',
+    source: expect.any(String),
+  })
+})
+
+test('emits manifest via this.emitFile', async () => {
+  const bundle = cloneObject(await bundlePromise)
+
+  await plugin.generateBundle.call(
+    context,
+    options,
+    bundle,
+    false,
+  )
+
+  expect(context.emitFile).toBeCalledTimes(3)
+
+  expect(context.emitFile).toBeCalledWith<[EmittedFile]>({
+    type: 'asset',
+    fileName: 'manifest.json',
     source: expect.any(String),
   })
 })
@@ -238,23 +252,6 @@ test('validates manifest', async () => {
   )
 
   expect(validate.validateManifest).toBeCalled()
-})
-
-test('emits manifest via this.emitFile', async () => {
-  const bundle = cloneObject(await bundlePromise)
-
-  await plugin.generateBundle.call(
-    context,
-    options,
-    bundle,
-    false,
-  )
-
-  expect(context.emitFile).toBeCalledWith<[EmittedFile]>({
-    type: 'asset',
-    fileName: 'manifest.json',
-    source: expect.any(String),
-  })
 })
 
 test('Sets cache.assetChanged to false if cache.permsHash is truthy', async () => {
@@ -342,6 +339,7 @@ test('emits correct paths on Windows', async () => {
           '48': 'images/icon-main-48.png',
           '128': 'images/icon-main-128.png',
         },
+        default_locale: 'en',
         devtools_page: 'devtools/devtools.html',
         background: {
           scripts: ['sample/file-path-background.js.js'],
@@ -386,4 +384,19 @@ test('emits correct paths on Windows', async () => {
       2,
     ),
   })
+})
+
+test('locales are included in bundle', async () => {
+  const bundle = cloneObject(await bundlePromise)
+
+  expect(bundle).toMatchObject({})
+
+  await plugin.generateBundle.call(
+    context,
+    options,
+    bundle,
+    false,
+  )
+
+  expect(bundle).toMatchObject({})
 })

--- a/src/manifest-input/manifest-parser/__tests__/mv2-manifest__unit--deriveFiles.test.ts
+++ b/src/manifest-input/manifest-parser/__tests__/mv2-manifest__unit--deriveFiles.test.ts
@@ -8,6 +8,8 @@ import {
   icon128,
   icon16,
   icon48,
+  localesEnJson,
+  localesEsJson,
   manifestJson,
   optionsHtml,
   popupHtml,
@@ -49,6 +51,13 @@ test('gets correct action img', () => {
   expect(result.img).toContain(icon16)
   expect(result.img).toContain(icon48)
   expect(result.img).toContain(icon128)
+})
+
+test('gets correct locales folder', () => {
+  const result = deriveFiles(manifest, srcDir)
+
+  expect(result.others).toContain(localesEnJson)
+  expect(result.others).toContain(localesEsJson)
 })
 
 test('does not emit duplicates', () => {

--- a/src/manifest-input/manifest-parser/__tests__/mv3-manifest__unit--deriveFiles.test.ts
+++ b/src/manifest-input/manifest-parser/__tests__/mv3-manifest__unit--deriveFiles.test.ts
@@ -7,6 +7,8 @@ import {
   icon128,
   icon16,
   icon48,
+  localesEnJson,
+  localesEsJson,
   manifestJson,
   optionsHtml,
   popupHtml,
@@ -49,6 +51,13 @@ test('gets correct action img', () => {
   expect(result.img).toContain(icon16)
   expect(result.img).toContain(icon48)
   expect(result.img).toContain(icon128)
+})
+
+test('gets correct locales folder', () => {
+  const result = deriveFiles(manifest, srcDir)
+
+  expect(result.others).toContain(localesEnJson)
+  expect(result.others).toContain(localesEsJson)
 })
 
 test('does not emit duplicates', () => {

--- a/src/manifest-input/manifest-parser/index.ts
+++ b/src/manifest-input/manifest-parser/index.ts
@@ -39,12 +39,17 @@ export function deriveFilesMV3(
   manifest: chrome.runtime.ManifestV3,
   srcDir: string,
 ) {
+  const locales = isString(manifest.default_locale)
+    ? ['_locales/**/messages.json']
+    : []
+
   const files = get(
     manifest,
     'web_accessible_resources',
     [] as Required<typeof manifest>['web_accessible_resources'],
   )
     .flatMap(({ resources }) => resources)
+    .concat(locales)
     .reduce((r, x) => {
       if (glob.hasMagic(x)) {
         const files = glob.sync(x, { cwd: srcDir })
@@ -117,18 +122,24 @@ export function deriveFilesMV2(
   manifest: chrome.runtime.ManifestV2,
   srcDir: string,
 ) {
+  const locales = isString(manifest.default_locale)
+    ? ['_locales/**/messages.json']
+    : []
+
   const files = get(
     manifest,
     'web_accessible_resources',
     [] as Required<typeof manifest>['web_accessible_resources'],
-  ).reduce((r, x) => {
-    if (glob.hasMagic(x)) {
-      const files = glob.sync(x, { cwd: srcDir })
-      return [...r, ...files.map((f) => f.replace(srcDir, ''))]
-    } else {
-      return [...r, x]
-    }
-  }, [] as string[])
+  )
+    .concat(locales)
+    .reduce((r, x) => {
+      if (glob.hasMagic(x)) {
+        const files = glob.sync(x, { cwd: srcDir })
+        return [...r, ...files.map((f) => f.replace(srcDir, ''))]
+      } else {
+        return [...r, x]
+      }
+    }, [] as string[])
 
   const js = [
     ...files.filter((f) => /\.[jt]sx?$/.test(f)),


### PR DESCRIPTION
The PR adds support for localizing Chrome Extensions. Create your localization folder and add the `default_locales` key to your manifest. The `_locales` folder will be copied over automatically.