### PR TITLE
Manifest as ts files

### DIFF
--- a/__fixtures__/extensions/mv3-manifest-ts-array-input/rollup.config.js
+++ b/__fixtures__/extensions/mv3-manifest-ts-array-input/rollup.config.js
@@ -1,0 +1,35 @@
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import typescript from '@rollup/plugin-typescript'
+
+import { getExtPath, getCrxName } from '../../utils'
+
+import { chromeExtension, simpleReloader } from '../../../src'
+
+const crxName = getCrxName(__filename)
+
+export default {
+  input: [
+    getExtPath(crxName, 'src', 'manifest.ts'),
+    getExtPath(crxName, 'src', 'script.ts'),
+  ],
+  output: {
+    dir: getExtPath(crxName, 'dist'),
+    format: 'esm',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+    sourcemap: 'inline',
+  },
+  plugins: [
+    chromeExtension(),
+    // Adds a Chrome extension reloader during watch mode
+    simpleReloader(),
+    resolve(),
+    commonjs({
+      namedExports: {
+        react: Object.keys(require('react')),
+        'react-dom': Object.keys(require('react-dom')),
+      },
+    }),
+    typescript(),
+  ],
+}

--- a/__fixtures__/extensions/mv3-manifest-ts-array-input/src/content.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-array-input/src/content.ts
@@ -1,0 +1,1 @@
+console.log('content script')

--- a/__fixtures__/extensions/mv3-manifest-ts-array-input/src/manifest.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-array-input/src/manifest.ts
@@ -1,0 +1,13 @@
+import { ManifestV3 } from '../../../../src'
+
+const config: ManifestV3 = {
+  content_scripts: [
+    {
+      js: ['content.ts'],
+      matches: ['https://*/*', 'http://*/*'],
+    },
+  ],
+  manifest_version: 3,
+}
+
+export default config

--- a/__fixtures__/extensions/mv3-manifest-ts-array-input/src/script.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-array-input/src/script.ts
@@ -1,0 +1,1 @@
+console.log('script')

--- a/__fixtures__/extensions/mv3-manifest-ts-object-input/rollup.config.js
+++ b/__fixtures__/extensions/mv3-manifest-ts-object-input/rollup.config.js
@@ -1,0 +1,35 @@
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import typescript from '@rollup/plugin-typescript'
+
+import { getExtPath, getCrxName } from '../../utils'
+
+import { chromeExtension, simpleReloader } from '../../../src'
+
+const crxName = getCrxName(__filename)
+
+export default {
+  input: {
+    manifest: getExtPath(crxName, 'src', 'manifest.ts'),
+    script: getExtPath(crxName, 'src', 'script.ts'),
+  },
+  output: {
+    dir: getExtPath(crxName, 'dist'),
+    format: 'esm',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+    sourcemap: 'inline',
+  },
+  plugins: [
+    chromeExtension(),
+    // Adds a Chrome extension reloader during watch mode
+    simpleReloader(),
+    resolve(),
+    commonjs({
+      namedExports: {
+        react: Object.keys(require('react')),
+        'react-dom': Object.keys(require('react-dom')),
+      },
+    }),
+    typescript(),
+  ],
+}

--- a/__fixtures__/extensions/mv3-manifest-ts-object-input/src/content.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-object-input/src/content.ts
@@ -1,0 +1,1 @@
+console.log('content script')

--- a/__fixtures__/extensions/mv3-manifest-ts-object-input/src/manifest.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-object-input/src/manifest.ts
@@ -1,0 +1,13 @@
+import { ManifestV3 } from '../../../../src'
+
+const config: ManifestV3 = {
+  content_scripts: [
+    {
+      js: ['content.ts'],
+      matches: ['https://*/*', 'http://*/*'],
+    },
+  ],
+  manifest_version: 3,
+}
+
+export default config

--- a/__fixtures__/extensions/mv3-manifest-ts-object-input/src/script.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-object-input/src/script.ts
@@ -1,0 +1,1 @@
+console.log('script')

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/rollup.config.js
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/rollup.config.js
@@ -1,0 +1,32 @@
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import typescript from '@rollup/plugin-typescript'
+
+import { getExtPath, getCrxName } from '../../utils'
+
+import { chromeExtension, simpleReloader } from '../../../src'
+
+const crxName = getCrxName(__filename)
+
+export default {
+  input: getExtPath(crxName, 'src', 'manifest.ts'),
+  output: {
+    dir: getExtPath(crxName, 'dist'),
+    format: 'esm',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+    sourcemap: 'inline',
+  },
+  plugins: [
+    chromeExtension(),
+    // Adds a Chrome extension reloader during watch mode
+    simpleReloader(),
+    resolve(),
+    commonjs({
+      namedExports: {
+        react: Object.keys(require('react')),
+        'react-dom': Object.keys(require('react-dom')),
+      },
+    }),
+    typescript(),
+  ],
+}

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/src/App.tsx
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/src/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const App: React.FC = () => {
+  return (
+    <div>
+      <h1>Popup Page</h1>
+      <p>If you are seeing this, React is working!</p>
+    </div>
+  )
+}
+
+export default App

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/src/content.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/src/content.ts
@@ -1,0 +1,1 @@
+console.log('content script')

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/src/manifest.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/src/manifest.ts
@@ -1,0 +1,19 @@
+import { ManifestV3 } from '../../../../src'
+
+const config: ManifestV3 = {
+  action: {
+    default_popup: 'popup.html',
+  },
+  background: {
+    service_worker: 'service_worker.ts',
+  },
+  content_scripts: [
+    {
+      js: ['content.ts'],
+      matches: ['https://*/*', 'http://*/*'],
+    },
+  ],
+  manifest_version: 3,
+}
+
+export default config

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/src/popup.html
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/src/popup.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=1000, initial-scale=1.0"
+    />
+    <title>Popup Page</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="popup.tsx"></script>
+  </body>
+</html>

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/src/popup.tsx
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/src/popup.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { render } from 'react-dom'
+import App from './App'
+
+console.log('popup script')
+
+const root = document.querySelector('#root')
+
+render(<App />, root)

--- a/__fixtures__/extensions/mv3-manifest-ts-single-input/src/service_worker.ts
+++ b/__fixtures__/extensions/mv3-manifest-ts-single-input/src/service_worker.ts
@@ -1,0 +1,1 @@
+console.log('service_worker.ts')

--- a/__tests__/e2e__mv3-manifest-ts-array-input.test.ts
+++ b/__tests__/e2e__mv3-manifest-ts-array-input.test.ts
@@ -1,0 +1,57 @@
+import path from 'path'
+import { rollup, RollupOptions, RollupOutput } from 'rollup'
+import { isAsset, isChunk } from '../src/helpers'
+import { deriveFiles } from '../src/manifest-input/manifest-parser'
+import { byFileName, getExtPath, getTestName, requireExtFile } from '../__fixtures__/utils'
+
+const testName = getTestName(__filename)
+const extPath = getExtPath(testName)
+
+let outputPromise: Promise<RollupOutput>
+beforeAll(async () => {
+  const config = requireExtFile(__filename, 'rollup.config.js') as RollupOptions
+  outputPromise = rollup(config).then((bundle) => bundle.generate(config.output as any))
+  return outputPromise
+}, 30000)
+
+test('bundles chunks and assets', async () => {
+  const { output } = await outputPromise
+
+  // Chunks
+  const chunks = output.filter(isChunk)
+  expect(chunks.find(byFileName('content.js'))).toBeDefined()
+  expect(chunks.find(byFileName('script.js'))).toBeDefined()
+
+  // 2 entries and 1 content script wrapper
+  expect(chunks.length).toBe(3)
+})
+
+test('bundles assets', async () => {
+  const { output } = await outputPromise
+
+  // Assets
+  const assets = output.filter(isAsset)
+  expect(assets.find(byFileName('manifest.json'))).toBeDefined()
+
+  // 1 manifest
+  expect(assets.length).toBe(1)
+})
+
+test('chunks in output match chunks in manifest', async () => {
+  const { output } = await outputPromise
+
+  const assets = output.filter(isAsset)
+  const manifestJson = assets.find(byFileName('manifest.json'))!
+  const manifest = JSON.parse(manifestJson.source as string) as chrome.runtime.Manifest
+
+  // Get scripts in manifest
+  const { js } = deriveFiles(manifest, extPath, { contentScripts: true })
+
+  js.map((x) => path.relative(extPath, x)).forEach((script) => {
+    const chunk = output.find(byFileName(script))
+    expect(chunk).toBeDefined()
+    if (chunk?.type === 'chunk') {
+      expect(typeof chunk?.map?.toUrl()).toBe('string')
+    }
+  })
+})

--- a/__tests__/e2e__mv3-manifest-ts-object-input.test.ts
+++ b/__tests__/e2e__mv3-manifest-ts-object-input.test.ts
@@ -1,0 +1,57 @@
+import path from 'path'
+import { rollup, RollupOptions, RollupOutput } from 'rollup'
+import { isAsset, isChunk } from '../src/helpers'
+import { deriveFiles } from '../src/manifest-input/manifest-parser'
+import { byFileName, getExtPath, getTestName, requireExtFile } from '../__fixtures__/utils'
+
+const testName = getTestName(__filename)
+const extPath = getExtPath(testName)
+
+let outputPromise: Promise<RollupOutput>
+beforeAll(async () => {
+  const config = requireExtFile(__filename, 'rollup.config.js') as RollupOptions
+  outputPromise = rollup(config).then((bundle) => bundle.generate(config.output as any))
+  return outputPromise
+}, 30000)
+
+test('bundles chunks and assets', async () => {
+  const { output } = await outputPromise
+
+  // Chunks
+  const chunks = output.filter(isChunk)
+  expect(chunks.find(byFileName('content.js'))).toBeDefined()
+  expect(chunks.find(byFileName('script.js'))).toBeDefined()
+
+  // 2 entries and 1 content script wrapper
+  expect(chunks.length).toBe(3)
+})
+
+test('bundles assets', async () => {
+  const { output } = await outputPromise
+
+  // Assets
+  const assets = output.filter(isAsset)
+  expect(assets.find(byFileName('manifest.json'))).toBeDefined()
+
+  // 1 manifest
+  expect(assets.length).toBe(1)
+})
+
+test('chunks in output match chunks in manifest', async () => {
+  const { output } = await outputPromise
+
+  const assets = output.filter(isAsset)
+  const manifestJson = assets.find(byFileName('manifest.json'))!
+  const manifest = JSON.parse(manifestJson.source as string) as chrome.runtime.Manifest
+
+  // Get scripts in manifest
+  const { js } = deriveFiles(manifest, extPath, { contentScripts: true })
+
+  js.map((x) => path.relative(extPath, x)).forEach((script) => {
+    const chunk = output.find(byFileName(script))
+    expect(chunk).toBeDefined()
+    if (chunk?.type === 'chunk') {
+      expect(typeof chunk?.map?.toUrl()).toBe('string')
+    }
+  })
+})

--- a/__tests__/e2e__mv3-manifest-ts-single-input.test.ts
+++ b/__tests__/e2e__mv3-manifest-ts-single-input.test.ts
@@ -1,0 +1,59 @@
+import path from 'path'
+import { rollup, RollupOptions, RollupOutput } from 'rollup'
+import { isAsset, isChunk } from '../src/helpers'
+import { deriveFiles } from '../src/manifest-input/manifest-parser'
+import { byFileName, getExtPath, getTestName, requireExtFile } from '../__fixtures__/utils'
+
+const testName = getTestName(__filename)
+const extPath = getExtPath(testName)
+
+let outputPromise: Promise<RollupOutput>
+beforeAll(async () => {
+  const config = requireExtFile(__filename, 'rollup.config.js') as RollupOptions
+  outputPromise = rollup(config).then((bundle) => bundle.generate(config.output as any))
+  return outputPromise
+}, 30000)
+
+test('bundles chunks and assets', async () => {
+  const { output } = await outputPromise
+
+  // Chunks
+  const chunks = output.filter(isChunk)
+  expect(chunks.find(byFileName('service_worker.js'))).toBeDefined()
+  expect(chunks.find(byFileName('content.js'))).toBeDefined()
+  expect(chunks.find(byFileName('popup.js'))).toBeDefined()
+
+  // 3 entries and 1 content script wrapper
+  expect(chunks.length).toBe(4)
+})
+
+test('bundles assets', async () => {
+  const { output } = await outputPromise
+
+  // Assets
+  const assets = output.filter(isAsset)
+  expect(assets.find(byFileName('manifest.json'))).toBeDefined()
+  expect(assets.find(byFileName('popup.html'))).toBeDefined()
+
+  // 1 html file and 1 manifest
+  expect(assets.length).toBe(2)
+})
+
+test('chunks in output match chunks in manifest', async () => {
+  const { output } = await outputPromise
+
+  const assets = output.filter(isAsset)
+  const manifestJson = assets.find(byFileName('manifest.json'))!
+  const manifest = JSON.parse(manifestJson.source as string) as chrome.runtime.Manifest
+
+  // Get scripts in manifest
+  const { js } = deriveFiles(manifest, extPath, { contentScripts: true })
+
+  js.map((x) => path.relative(extPath, x)).forEach((script) => {
+    const chunk = output.find(byFileName(script))
+    expect(chunk).toBeDefined()
+    if (chunk?.type === 'chunk') {
+      expect(typeof chunk?.map?.toUrl()).toBe('string')
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mem": "^6.0.1",
     "rollup": "^1.31.0",
     "slash": "^3.0.0",
+    "ts-node": "^10.2.0",
     "webextension-polyfill": "^0.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,7 @@ specifiers:
   rxjs: ^7.3.0
   slash: ^3.0.0
   ts-jest: '26'
+  ts-node: ^10.2.0
   tslib: ^2.3.0
   typescript: ^4.3.5
   webextension-polyfill: ^0.6.0
@@ -81,6 +82,7 @@ dependencies:
   mem: 6.1.1
   rollup: 1.32.1
   slash: 3.0.0
+  ts-node: 10.2.0_3199196ab4f65c5c1a2d8fe509af1024
   webextension-polyfill: 0.6.0
 
 devDependencies:
@@ -115,9 +117,9 @@ devDependencies:
   '@typescript-eslint/parser': 4.29.0_eslint@6.8.0+typescript@4.3.5
   eslint: 6.8.0
   eslint-plugin-react: 7.22.0_eslint@6.8.0
-  jest: 26.6.3
+  jest: 26.6.3_ts-node@10.2.0
   jest-chrome: 0.7.0_jest@26.6.3
-  jest-circus: 26.6.3
+  jest-circus: 26.6.3_ts-node@10.2.0
   jest-html-reporters: 1.2.1
   jest-in-case: 1.0.2
   npm-run-all: 4.1.5
@@ -1408,6 +1410,18 @@ packages:
       minimist: 1.2.5
     dev: true
 
+  /@cspotcode/source-map-consumer/0.8.0:
+    resolution: {integrity: sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==}
+    engines: {node: '>= 12'}
+    dev: false
+
+  /@cspotcode/source-map-support/0.6.1:
+    resolution: {integrity: sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@cspotcode/source-map-consumer': 0.8.0
+    dev: false
+
   /@extend-chrome/messages/1.2.2:
     resolution: {integrity: sha512-1VyUCT+1jewkm7cVBE5fMrrazxuL5QrmCOg2azmItBpiTqwmV/XxhGDQAtfsT4i24xB4gwL0s7+6PpEPec+1mw==}
     dependencies:
@@ -1451,7 +1465,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/26.6.3:
+  /@jest/core/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==}
     engines: {node: '>= 10.14.2'}
     dependencies:
@@ -1466,14 +1480,14 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.6
       jest-changed-files: 26.6.2
-      jest-config: 26.6.3
+      jest-config: 26.6.3_ts-node@10.2.0
       jest-haste-map: 26.6.2
       jest-message-util: 26.6.2
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3
-      jest-runtime: 26.6.3
+      jest-runner: 26.6.3_ts-node@10.2.0
+      jest-runtime: 26.6.3_ts-node@10.2.0
       jest-snapshot: 26.6.2
       jest-util: 26.6.2
       jest-validate: 26.6.2
@@ -1575,15 +1589,15 @@ packages:
       collect-v8-coverage: 1.0.1
     dev: true
 
-  /@jest/test-sequencer/26.6.3:
+  /@jest/test-sequencer/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==}
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/test-result': 26.6.2
       graceful-fs: 4.2.6
       jest-haste-map: 26.6.2
-      jest-runner: 26.6.3
-      jest-runtime: 26.6.3
+      jest-runner: 26.6.3_ts-node@10.2.0
+      jest-runtime: 26.6.3_ts-node@10.2.0
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -1812,6 +1826,22 @@ packages:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
     dev: true
+
+  /@tsconfig/node10/1.0.8:
+    resolution: {integrity: sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==}
+    dev: false
+
+  /@tsconfig/node12/1.0.9:
+    resolution: {integrity: sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==}
+    dev: false
+
+  /@tsconfig/node14/1.0.1:
+    resolution: {integrity: sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==}
+    dev: false
+
+  /@tsconfig/node16/1.0.2:
+    resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
+    dev: false
 
   /@types/babel__core/7.1.15:
     resolution: {integrity: sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==}
@@ -2226,6 +2256,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /acorn-walk/8.1.1:
+    resolution: {integrity: sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /acorn/7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
@@ -2235,7 +2270,6 @@ packages:
     resolution: {integrity: sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /agent-base/6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -2319,6 +2353,10 @@ packages:
       normalize-path: 3.0.0
       picomatch: 2.3.0
     dev: true
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: false
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2874,6 +2912,10 @@ packages:
       yaml: 1.10.0
     dev: false
 
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: false
+
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -3052,6 +3094,11 @@ packages:
     resolution: {integrity: sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==}
     engines: {node: '>= 10.14.2'}
     dev: true
+
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -4192,10 +4239,10 @@ packages:
       jest: ^24.9.0
     dependencies:
       '@types/chrome': 0.0.114
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@10.2.0
     dev: true
 
-  /jest-circus/26.6.3:
+  /jest-circus/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==}
     engines: {node: '>= 10.14.2'}
     dependencies:
@@ -4213,8 +4260,8 @@ packages:
       jest-each: 26.6.2
       jest-matcher-utils: 26.6.2
       jest-message-util: 26.6.2
-      jest-runner: 26.6.3
-      jest-runtime: 26.6.3
+      jest-runner: 26.6.3_ts-node@10.2.0
+      jest-runtime: 26.6.3_ts-node@10.2.0
       jest-snapshot: 26.6.2
       jest-util: 26.6.2
       pretty-format: 26.6.2
@@ -4228,12 +4275,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-cli/26.6.3:
+  /jest-cli/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==}
     engines: {node: '>= 10.14.2'}
     hasBin: true
     dependencies:
-      '@jest/core': 26.6.3
+      '@jest/core': 26.6.3_ts-node@10.2.0
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
       chalk: 4.1.2
@@ -4241,7 +4288,7 @@ packages:
       graceful-fs: 4.2.6
       import-local: 3.0.2
       is-ci: 2.0.0
-      jest-config: 26.6.3
+      jest-config: 26.6.3_ts-node@10.2.0
       jest-util: 26.6.2
       jest-validate: 26.6.2
       prompts: 2.4.1
@@ -4254,7 +4301,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/26.6.3:
+  /jest-config/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==}
     engines: {node: '>= 10.14.2'}
     peerDependencies:
@@ -4264,7 +4311,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.14.8
-      '@jest/test-sequencer': 26.6.3
+      '@jest/test-sequencer': 26.6.3_ts-node@10.2.0
       '@jest/types': 26.6.2
       babel-jest: 26.6.3_@babel+core@7.14.8
       chalk: 4.1.2
@@ -4274,13 +4321,14 @@ packages:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3
+      jest-jasmine2: 26.6.3_ts-node@10.2.0
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
       jest-validate: 26.6.2
       micromatch: 4.0.4
       pretty-format: 26.6.2
+      ts-node: 10.2.0_3199196ab4f65c5c1a2d8fe509af1024
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -4396,7 +4444,7 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /jest-jasmine2/26.6.3:
+  /jest-jasmine2/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==}
     engines: {node: '>= 10.14.2'}
     dependencies:
@@ -4413,7 +4461,7 @@ packages:
       jest-each: 26.6.2
       jest-matcher-utils: 26.6.2
       jest-message-util: 26.6.2
-      jest-runtime: 26.6.3
+      jest-runtime: 26.6.3_ts-node@10.2.0
       jest-snapshot: 26.6.2
       jest-util: 26.6.2
       pretty-format: 26.6.2
@@ -4507,7 +4555,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /jest-runner/26.6.3:
+  /jest-runner/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==}
     engines: {node: '>= 10.14.2'}
     dependencies:
@@ -4520,13 +4568,13 @@ packages:
       emittery: 0.7.2
       exit: 0.1.2
       graceful-fs: 4.2.6
-      jest-config: 26.6.3
+      jest-config: 26.6.3_ts-node@10.2.0
       jest-docblock: 26.0.0
       jest-haste-map: 26.6.2
       jest-leak-detector: 26.6.2
       jest-message-util: 26.6.2
       jest-resolve: 26.6.2
-      jest-runtime: 26.6.3
+      jest-runtime: 26.6.3_ts-node@10.2.0
       jest-util: 26.6.2
       jest-worker: 26.6.2
       source-map-support: 0.5.19
@@ -4539,7 +4587,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-runtime/26.6.3:
+  /jest-runtime/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==}
     engines: {node: '>= 10.14.2'}
     hasBin: true
@@ -4559,7 +4607,7 @@ packages:
       exit: 0.1.2
       glob: 7.1.7
       graceful-fs: 4.2.6
-      jest-config: 26.6.3
+      jest-config: 26.6.3_ts-node@10.2.0
       jest-haste-map: 26.6.2
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
@@ -4655,14 +4703,14 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /jest/26.6.3:
+  /jest/26.6.3_ts-node@10.2.0:
     resolution: {integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==}
     engines: {node: '>= 10.14.2'}
     hasBin: true
     dependencies:
-      '@jest/core': 26.6.3
+      '@jest/core': 26.6.3_ts-node@10.2.0
       import-local: 3.0.2
-      jest-cli: 26.6.3
+      jest-cli: 26.6.3_ts-node@10.2.0
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -4905,7 +4953,6 @@ packages:
 
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-    dev: true
 
   /makeerror/1.0.11:
     resolution: {integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=}
@@ -6445,7 +6492,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.2
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@10.2.0
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21
@@ -6455,6 +6502,37 @@ packages:
       typescript: 4.3.5
       yargs-parser: 20.2.9
     dev: true
+
+  /ts-node/10.2.0_3199196ab4f65c5c1a2d8fe509af1024:
+    resolution: {integrity: sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.6.1
+      '@tsconfig/node10': 1.0.8
+      '@tsconfig/node12': 1.0.9
+      '@tsconfig/node14': 1.0.1
+      '@tsconfig/node16': 1.0.2
+      '@types/node': 13.13.41
+      acorn: 8.4.1
+      acorn-walk: 8.1.1
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.3.5
+      yn: 3.1.1
+    dev: false
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -6795,3 +6873,8 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
     dev: true
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: false

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,10 +46,6 @@ export function isPresent<T>(x: null | undefined | T): x is T {
   return !isUndefined(x) && !isNull(x)
 }
 
-export function isJsonFilePath(x: any): x is string {
-  return isString(x) && x.endsWith('json')
-}
-
 export const normalizeFilename = (p: string) =>
   p.replace(/\.[tj]sx?$/, '.js')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { mixedFormat as m } from './mixed-format'
 
 export { simpleReloader } from './plugin-reloader-simple'
 
+export { ManifestV2, ManifestV3 } from './manifest-types'
+
 export const chromeExtension = (
   options = {} as ChromeExtensionOptions,
 ): ChromeExtensionPlugin => {

--- a/src/manifest-input/__tests__/manifest__hook--options.test.ts
+++ b/src/manifest-input/__tests__/manifest__hook--options.test.ts
@@ -100,20 +100,25 @@ test('does not mutate the options object', () => {
 })
 
 test('throws if input does not contain a manifest', () => {
-  const errorMessage =
-    'RollupOptions.input must be a single Chrome extension manifest.'
-
   expect(() => {
     plugin.options.call(context, {
       input: ['not-a-manifest'],
     })
-  }).toThrow(new TypeError(errorMessage))
+  }).toThrow(
+    new TypeError(
+      'Could not find manifest in Rollup options.input: ["not-a-manifest"]',
+    ),
+  )
 
   expect(() => {
     plugin.options.call(context, {
       input: { wrong: 'not-a-manifest' },
     })
-  }).toThrow(new TypeError(errorMessage))
+  }).toThrow(
+    new TypeError(
+      'Could not find manifest in Rollup options.input: {"wrong":"not-a-manifest"}',
+    ),
+  )
 })
 
 test('handles input array', () => {
@@ -251,7 +256,9 @@ test('should throw if cosmiconfig cannot load manifest file', () => {
     })
   }
 
-  expect(call).toThrow(/^ENOENT: no such file or directory/)
+  expect(call).toThrow(
+    /^Could not load manifest: not-a-manifest\.json does not exist/,
+  )
 })
 
 test('should throw if manifest file is empty', () => {

--- a/src/manifest-input/crypto.ts
+++ b/src/manifest-input/crypto.ts
@@ -1,7 +1,8 @@
 import { createHash as cryptoCreateHash } from 'crypto'
 
-export function hashCode(code: string) {
+export function hashCode(code: string, id: string) {
   const hash = cryptoCreateHash('sha256')
   hash.update(code)
+  hash.update(id)
   return hash.digest('hex').substr(0, 8)
 }

--- a/src/manifest-input/getInputManifestPath.ts
+++ b/src/manifest-input/getInputManifestPath.ts
@@ -1,0 +1,70 @@
+import { existsSync } from 'fs'
+import { basename } from 'path'
+import { InputOptions } from 'rollup'
+import { isString, isUndefined } from '../helpers'
+import { ManifestInputPluginCache } from '../plugin-options'
+import { cloneObject } from './cloneObject'
+
+const isManifestFileName = (filename: string) =>
+  basename(filename).startsWith('manifest')
+
+const validateFileName = (
+  filename: string,
+  { input }: InputOptions,
+) => {
+  if (isUndefined(filename))
+    throw new Error(
+      `Could not find manifest in Rollup options.input: ${JSON.stringify(
+        input,
+      )}`,
+    )
+  if (!existsSync(filename))
+    throw new Error(
+      `Could not load manifest: ${filename} does not exist`,
+    )
+
+  return filename
+}
+
+export function getInputManifestPath(
+  options: InputOptions,
+): Partial<
+  Pick<ManifestInputPluginCache, 'inputAry' | 'inputObj'>
+> & {
+  inputManifestPath: string
+} {
+  if (Array.isArray(options.input)) {
+    const manifestIndex = options.input.findIndex(
+      isManifestFileName,
+    )
+    const inputAry = [
+      ...options.input.slice(0, manifestIndex),
+      ...options.input.slice(manifestIndex + 1),
+    ]
+    const inputManifestPath = validateFileName(
+      options.input[manifestIndex],
+      options,
+    )
+
+    return { inputManifestPath, inputAry }
+  } else if (typeof options.input === 'object') {
+    const inputManifestPath = validateFileName(
+      options.input.manifest,
+      options,
+    )
+    const inputObj = cloneObject(options.input)
+    delete inputObj['manifest']
+
+    return { inputManifestPath, inputObj }
+  } else if (isString(options.input)) {
+    const inputManifestPath = validateFileName(
+      options.input,
+      options,
+    )
+    return { inputManifestPath }
+  }
+
+  throw new TypeError(
+    `Rollup options.input cannot be type "${typeof options.input}"`,
+  )
+}

--- a/src/manifest-input/index.ts
+++ b/src/manifest-input/index.ts
@@ -28,6 +28,7 @@ import {
 } from './manifest-parser/index'
 import { validateManifest } from './manifest-parser/validate'
 import { reduceToRecord } from './reduceToRecord'
+import { warnDeprecatedOptions } from './warnDeprecatedOptions'
 
 export const explorer = cosmiconfigSync('manifest', {
   cache: false,
@@ -351,47 +352,21 @@ export function manifestInput(
         this.emitFile(asset)
       })
 
-      /* ------------ WARN DEPRECATED OPTIONS ------------ */
-
-      if (crossBrowser)
-        this.warn(
-          '`options.crossBrowser` is not implemented yet',
-        )
-
-      if (!firstClassManifest)
-        this.warn(
-          '`options.firstClassManifest` will be removed in version 5.0.0',
-        )
-
-      if (iifeJsonPaths.length)
-        this.warn(
-          '`options.iifeJsonPaths` is not implemented yet',
-        )
+      warnDeprecatedOptions.call(
+        this,
+        {
+          browserPolyfill,
+          crossBrowser,
+          dynamicImportWrapper,
+          firstClassManifest,
+          iifeJsonPaths,
+          publicKey,
+        },
+        cache,
+      )
 
       // MV2 manifest is handled in `generateBundle`
       if (isMV2(cache.manifest)) return
-
-      if (browserPolyfill)
-        this.warn(
-          [
-            '`options.browserPolyfill` is deprecated for MV3 and does nothing internally',
-            'See: https://extend-chrome.dev/rollup-plugin#mv3-faq',
-          ].join('\n'),
-        )
-
-      if (dynamicImportWrapper !== true)
-        this.warn(
-          '`options.dynamicImportWrapper` is not required for MV3',
-        )
-
-      if (publicKey)
-        this.warn(
-          [
-            '`options.publicKey` is deprecated for MV3,',
-            'please use `options.extendManifest` instead',
-            'see: https://extend-chrome.dev/rollup-plugin#mv3-faq',
-          ].join('\n'),
-        )
 
       /* --------------- EMIT MV3 MANIFEST --------------- */
 

--- a/src/manifest-input/updateManifest.ts
+++ b/src/manifest-input/updateManifest.ts
@@ -1,0 +1,69 @@
+import { RollupOptions } from 'rollup'
+import { ManifestInputPluginCache } from '../plugin-options'
+import { cloneObject } from './cloneObject'
+
+export function updateManifestV3(
+  m: chrome.runtime.ManifestV3,
+  options: RollupOptions,
+  cache: ManifestInputPluginCache,
+) {
+  const manifest = cloneObject(m)
+
+  if (manifest.background) {
+    manifest.background.type = 'module'
+  }
+
+  if (manifest.content_scripts) {
+    const { output = {} } = options
+    const {
+      chunkFileNames = 'chunks/[name]-[hash].js',
+    } = Array.isArray(output) ? output[0] : output
+
+    cache.chunkFileNames = chunkFileNames
+
+    // Output could be an array
+    if (Array.isArray(output)) {
+      if (
+        // Should only be one value for chunkFileNames
+        output.reduce(
+          (r, x) => r.add(x.chunkFileNames ?? 'no cfn'),
+          new Set(),
+        ).size > 1
+      )
+        // We need to know chunkFileNames now, before the output stage
+        throw new TypeError(
+          'Multiple output values for chunkFileNames are not supported',
+        )
+
+      // If chunkFileNames is undefined, use our default
+      output.forEach((x) => (x.chunkFileNames = chunkFileNames))
+    } else {
+      // If chunkFileNames is undefined, use our default
+      output.chunkFileNames = chunkFileNames
+    }
+
+    const allMatches = manifest.content_scripts
+      .flatMap(({ matches }) => matches ?? [])
+      .concat(manifest.host_permissions ?? [])
+
+    const matches = Array.from(new Set(allMatches))
+    const resources = [
+      `${chunkFileNames
+        .split('/')
+        .join('/')
+        .replace('[format]', '*')
+        .replace('[name]', '*')
+        .replace('[hash]', '*')}`,
+    ]
+
+    manifest.web_accessible_resources =
+      manifest.web_accessible_resources ?? []
+
+    manifest.web_accessible_resources.push({
+      resources,
+      matches,
+    })
+  }
+
+  return manifest
+}

--- a/src/manifest-input/warnDeprecatedOptions.ts
+++ b/src/manifest-input/warnDeprecatedOptions.ts
@@ -1,0 +1,64 @@
+import { PluginContext } from 'rollup'
+import { isMV2 } from '../manifest-types'
+import {
+  ManifestInputPluginCache,
+  ManifestInputPluginOptions,
+} from '../plugin-options'
+
+export function warnDeprecatedOptions(
+  this: PluginContext,
+  {
+    browserPolyfill,
+    crossBrowser,
+    dynamicImportWrapper,
+    firstClassManifest,
+    iifeJsonPaths,
+    publicKey,
+  }: Pick<
+    ManifestInputPluginOptions,
+    | 'crossBrowser'
+    | 'browserPolyfill'
+    | 'firstClassManifest'
+    | 'iifeJsonPaths'
+    | 'dynamicImportWrapper'
+    | 'publicKey'
+  >,
+  cache: ManifestInputPluginCache,
+) {
+  /* ------------ WARN DEPRECATED OPTIONS ------------ */
+  if (crossBrowser)
+    this.warn('`options.crossBrowser` is not implemented yet')
+
+  if (!firstClassManifest)
+    this.warn(
+      '`options.firstClassManifest` will be removed in version 5.0.0',
+    )
+
+  if (iifeJsonPaths?.length)
+    this.warn('`options.iifeJsonPaths` is not implemented yet')
+
+  // MV2 manifest is handled in `generateBundle`
+  if (isMV2(cache.manifest)) return
+
+  if (browserPolyfill)
+    this.warn(
+      [
+        '`options.browserPolyfill` is deprecated for MV3 and does nothing internally',
+        'See: https://extend-chrome.dev/rollup-plugin#mv3-faq',
+      ].join('\n'),
+    )
+
+  if (dynamicImportWrapper !== true)
+    this.warn(
+      '`options.dynamicImportWrapper` is not required for MV3',
+    )
+
+  if (publicKey)
+    this.warn(
+      [
+        '`options.publicKey` is deprecated for MV3,',
+        'please use `options.extendManifest` instead',
+        'see: https://extend-chrome.dev/rollup-plugin#mv3-faq',
+      ].join('\n'),
+    )
+}

--- a/src/manifest-types.ts
+++ b/src/manifest-types.ts
@@ -1,19 +1,33 @@
 import { isPresent, Unpacked } from './helpers'
 
-export type MV2 = chrome.runtime.Manifest & {
-  manifest_version: 2
-}
+export type ManifestV2 = Omit<
+  chrome.runtime.ManifestV2,
+  'name' | 'description' | 'version'
+> &
+  Partial<
+    Pick<
+      chrome.runtime.ManifestV2,
+      'name' | 'description' | 'version'
+    >
+  >
 
-export type MV3 = chrome.runtime.Manifest & {
-  manifest_version: 3
-}
+export type ManifestV3 = Omit<
+  chrome.runtime.ManifestV3,
+  'name' | 'description' | 'version'
+> &
+  Partial<
+    Pick<
+      chrome.runtime.ManifestV3,
+      'name' | 'description' | 'version'
+    >
+  >
 
 export type ContentScript = Unpacked<
   chrome.runtime.Manifest['content_scripts']
 >
 
 export type WebAccessibleResource = Unpacked<
-  MV3['web_accessible_resources']
+  chrome.runtime.ManifestV3['web_accessible_resources']
 >
 
 export function isMV2(


### PR DESCRIPTION
This PR leverages `ts-node` to allow manifest files to be TS files. Type checking and environment variables are here!

```typescript
import { ManifestV3 } from 'rollup-plugin-chrome-extension'

const config: ManifestV3 = {
  content_scripts: [
    {
      js: ['content.ts'],
      matches: ['https://*/*', 'http://*/*'],
    },
  ],
  manifest_version: 3,
}

export default config
```