### PR TITLE
Fix invalid match patterns in auto-generated web accessible resources

### DIFF
--- a/src/manifest-input/__tests__/manifest__mv3-unit-convertMatchPatterns.ts
+++ b/src/manifest-input/__tests__/manifest__mv3-unit-convertMatchPatterns.ts
@@ -1,0 +1,14 @@
+import { convertMatchPatterns } from '../convertMatchPatterns'
+
+test.each`
+  matchPattern                                  | expected
+  ${'http://localhost:3000/*'}                  | ${'http://localhost:3000/*'}
+  ${'http://localhost:*/*'}                     | ${'http://localhost:*/*'}
+  ${'*://www.google.com/search*'}               | ${'*://www.google.com/*'}
+  ${'https://*.expedia.com/Flights*'}           | ${'https://*.expedia.com/*'}
+  ${'https://*.kayak.com/*'}                    | ${'https://*.kayak.com/*'}
+  ${'https://flights.booking.com/*'}            | ${'https://flights.booking.com/*'}
+  ${'https://www.priceline.com/m/fly/search/*'} | ${'https://www.priceline.com/*'}
+`('converts match patterns', ({ matchPattern, expected }) => {
+  expect(convertMatchPatterns(matchPattern)).toBe(expected)
+})

--- a/src/manifest-input/convertMatchPatterns.ts
+++ b/src/manifest-input/convertMatchPatterns.ts
@@ -1,0 +1,22 @@
+export const convertMatchPatterns = (m: string): string => {
+  // Use URL to parse match pattern
+  // URL must have valid url scheme
+  const [scheme, rest] = m.split('://')
+
+  // URL must have valid port
+  const [a, port, b] = rest.split(/(:\*)/)
+  const isWildPort = port === ':*'
+  const frag = isWildPort ? `${a}:3333${b}` : rest
+
+  // match patterns can only define origin
+  const { origin } = new URL(`http://${frag}`)
+  const [, base] = origin.split('://')
+
+  // put port back
+  const [x, y] = base.split(':3333')
+  const final = isWildPort ? [x, port, y].join('') : base
+
+  // URL escapes asterixes
+  // Need to unescape them
+  return unescape(`${scheme}://${final}/*`)
+}

--- a/src/manifest-input/updateManifest.ts
+++ b/src/manifest-input/updateManifest.ts
@@ -1,6 +1,7 @@
 import { RollupOptions } from 'rollup'
 import { ManifestInputPluginCache } from '../plugin-options'
 import { cloneObject } from './cloneObject'
+import { convertMatchPatterns } from './convertMatchPatterns'
 
 export function updateManifestV3(
   m: chrome.runtime.ManifestV3,
@@ -46,7 +47,9 @@ export function updateManifestV3(
       .flatMap(({ matches }) => matches ?? [])
       .concat(manifest.host_permissions ?? [])
 
-    const matches = Array.from(new Set(allMatches))
+    const matches = Array.from(new Set(allMatches)).map(
+      convertMatchPatterns,
+    )
     const resources = [
       `${chunkFileNames
         .split('/')


### PR DESCRIPTION
This PR fixes a bug that prevents Chrome from loading an extension with auto-generated web accessible resources (WAR) that support ESM content scripts. 

The MV3 WAR format includes a `matches` property that appears to be identical to the content script `matches` property. The WAR `matches` property matches the origin of a URL, not the full URL like a content script. This means that the content script matches property cannot be directly copied to WAR.

Here we're deconstructing the match pattern and pulling out the origin to recreate a valid WAR match pattern.