### PR TITLE
Fix external XHR requests while using Vite and HMR

### DIFF
--- a/src/service-worker/code-fetchHandlerForMV3HMR.ts
+++ b/src/service-worker/code-fetchHandlerForMV3HMR.ts
@@ -6,7 +6,9 @@ self.skipWaiting()
 
 self.addEventListener('fetch', (fetchEvent) => {
   const url = new URL(fetchEvent.request.url)
-  fetchEvent.respondWith(mapRequestsToLocalhost(url.href))
+  if (url.protocol === 'chrome-extension:') {
+    fetchEvent.respondWith(mapRequestsToLocalhost(url.href))
+  }
 })
 
 function mapRequestsToLocalhost(

--- a/test/e2e/mv3-vite-hmr-external-xhr/src/App.tsx
+++ b/test/e2e/mv3-vite-hmr-external-xhr/src/App.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+const App: React.FC = () => {
+  const [ok, setOk] = React.useState(false)
+  React.useEffect(() => {
+    fetch('http://mock-api-route.test/')
+      .then((res) => {
+        return res.text()
+      })
+      .then((text) => {
+        if (text === 'ok') {
+          setOk(true)
+        }
+      })
+  }, [setOk])
+  return (
+    <div>
+      <h1>HMR + External XHR Test</h1>
+      <p>
+        Received successful response from external XHR:{' '}
+        {ok ? 'Yes' : 'No'}
+      </p>
+    </div>
+  )
+}
+
+export default App

--- a/test/e2e/mv3-vite-hmr-external-xhr/src/manifest.json
+++ b/test/e2e/mv3-vite-hmr-external-xhr/src/manifest.json
@@ -1,0 +1,7 @@
+{
+  "background": {
+    "service_worker": "service_worker.ts"
+  },
+  "options_page": "options.html",
+  "manifest_version": 3
+}

--- a/test/e2e/mv3-vite-hmr-external-xhr/src/options.html
+++ b/test/e2e/mv3-vite-hmr-external-xhr/src/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=1000, initial-scale=1.0"
+    />
+    <title>Options Page</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./options.tsx"></script>
+  </body>
+</html>

--- a/test/e2e/mv3-vite-hmr-external-xhr/src/options.tsx
+++ b/test/e2e/mv3-vite-hmr-external-xhr/src/options.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { render } from 'react-dom'
+import App from './App'
+
+const root = document.querySelector('#root')
+render(<App />, root)

--- a/test/e2e/mv3-vite-hmr-external-xhr/src/service_worker.ts
+++ b/test/e2e/mv3-vite-hmr-external-xhr/src/service_worker.ts
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.runtime.openOptionsPage()
+})

--- a/test/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
+++ b/test/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
@@ -26,15 +26,6 @@ beforeAll(async () => {
     build: { outDir },
   })
 
-  devServer.middlewares.use(
-    '/api/ok',
-    function MockApiHandler(req, res, next) {
-      res.write('ok')
-      next()
-    },
-  )
-  console.log(devServer.middlewares)
-
   await Promise.all([devServer.listen(), filesReady()])
 
   browserContext = (await chromium.launchPersistentContext(

--- a/test/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
+++ b/test/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
@@ -1,0 +1,91 @@
+import { filesReady } from '$src/plugin-viteServeFileWriter'
+import { jestSetTimeout, timeLimit } from '$test/helpers/timeout'
+import fs from 'fs-extra'
+import path from 'path'
+import {
+  chromium,
+  ChromiumBrowserContext,
+  Page,
+} from 'playwright-chromium'
+import { createServer, ViteDevServer } from 'vite'
+
+jestSetTimeout(180000)
+
+const outDir = path.join(__dirname, 'dist-vite-serve')
+const dataDir = path.join(__dirname, 'chromium-data-dir-serve')
+
+let browserContext: ChromiumBrowserContext
+let devServer: ViteDevServer
+let page: Page
+beforeAll(async () => {
+  await fs.remove(outDir)
+
+  devServer = await createServer({
+    configFile: path.join(__dirname, 'vite.config.ts'),
+    envFile: false,
+    build: { outDir },
+  })
+
+  devServer.middlewares.use(
+    '/api/ok',
+    function MockApiHandler(req, res, next) {
+      res.write('ok')
+      next()
+    },
+  )
+  console.log(devServer.middlewares)
+
+  await Promise.all([devServer.listen(), filesReady()])
+
+  browserContext = (await chromium.launchPersistentContext(
+    dataDir,
+    {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${outDir}`,
+        `--load-extension=${outDir}`,
+      ],
+    },
+  )) as ChromiumBrowserContext
+})
+
+afterAll(async () => {
+  await browserContext?.close()
+
+  // MV3 service worker is unresponsive if this directory exists from a previous run
+  await fs.remove(dataDir)
+})
+
+test('CRX loads and runs successfully', async () => {
+  // creates a mock route handler that returns ok
+  // which allows the options page to fetch an "external" resource
+  await browserContext.route(
+    'http://mock-api-route.test/',
+    (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'ok',
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+      })
+    },
+  )
+  page = await browserContext.newPage()
+  // we wait for one second for the browser to initialize and the background script's onInstalled handler to fire and open the options page
+  await page.waitForTimeout(1000)
+  const pages = await browserContext.pages()
+  // to test for text on the options page, we need to find the newly opened extension page that was opened by the background script on install
+  const optionsPage = pages.find((p) =>
+    p.url().includes('chrome-extension://'),
+  )
+  if (optionsPage) {
+    // we need to reload the options page, because many times on initial load, the bundler has not finished and we're returned a blank options page with no content
+    // this might be something to improve later, since in theory we're checking for files ready, but that doesn't always happen. forcing a reload seems to make it work consistently
+    await optionsPage.reload()
+    await optionsPage.waitForSelector('text=external XHR: Yes')
+  } else {
+    throw new Error('Options page was not opened')
+  }
+})

--- a/test/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
+++ b/test/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
@@ -1,5 +1,5 @@
 import { filesReady } from '$src/plugin-viteServeFileWriter'
-import { jestSetTimeout, timeLimit } from '$test/helpers/timeout'
+import { jestSetTimeout } from '$test/helpers/timeout'
 import fs from 'fs-extra'
 import path from 'path'
 import {
@@ -9,7 +9,7 @@ import {
 } from 'playwright-chromium'
 import { createServer, ViteDevServer } from 'vite'
 
-jestSetTimeout(180000)
+jestSetTimeout(30000)
 
 const outDir = path.join(__dirname, 'dist-vite-serve')
 const dataDir = path.join(__dirname, 'chromium-data-dir-serve')

--- a/test/e2e/mv3-vite-hmr-external-xhr/vite.config.ts
+++ b/test/e2e/mv3-vite-hmr-external-xhr/vite.config.ts
@@ -1,0 +1,20 @@
+import { chromeExtension } from '$src'
+import path from 'path'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig(() => ({
+  root: path.join(__dirname, 'src'),
+  clearScreen: false,
+  logLevel: 'error',
+  build: {
+    minify: false,
+    emptyOutDir: true,
+    sourcemap: 'inline',
+  },
+  plugins: [chromeExtension(), react()],
+  cacheDir: path.join(__dirname, '.vite'),
+  optimizeDeps: {
+    include: ['react', 'react-dom'],
+  },
+}))


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

https://github.com/extend-chrome/rollup-plugin-chrome-extension/pull/117#issuecomment-993002247
### Description

When using Vite with v4 of this plugin, if you have an extension or popup page that makes an external XHR request, that request gets redirected to the local server. This is because the background service worker that routes `chrome-extension://` requests to the local server so that HMR can work is routing _all_ requests, instead of just the relevant ones for HMR.

This fixes that issue by adding a check for the protocol, and only mapping the requests to localhost if the protocol matches `chrome-extension://`.