### PR TITLE
Fix sw binary bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm i rollup-plugin-chrome-extension@beta -D
 
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import chromeExtension from 'rollup-plugin-chrome-extension'
+import { chromeExtension } from 'rollup-plugin-chrome-extension'
 
 export default defineConfig({
   plugins: [react(), chromeExtension()],

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,5 +370,3 @@ export const chromeExtension = (
     },
   }
 }
-
-export default chromeExtension

--- a/src/service-worker/code-fetchHandlerForMV3HMR.ts
+++ b/src/service-worker/code-fetchHandlerForMV3HMR.ts
@@ -20,12 +20,11 @@ function mapRequestsToLocalhost(
   url.host = 'localhost'
   url.port = JSON.parse('%VITE_SERVE_PORT%')
 
-  return fetch(url.href).then(async (r) => {
-    const body = await r.text()
+  return fetch(url.href).then((r) => {
     const contentType =
       r.headers.get('Content-Type') ?? 'text/javascript'
 
-    return new Response(body, {
+    return new Response(r.body, {
       headers: {
         'Content-Type': contentType,
       },

--- a/src/service-worker/code-fetchHandlerForMV3HMR.ts
+++ b/src/service-worker/code-fetchHandlerForMV3HMR.ts
@@ -4,9 +4,10 @@ export {}
 
 self.skipWaiting()
 
+const ownOrigin = new URL(chrome.runtime.getURL('/')).origin
 self.addEventListener('fetch', (fetchEvent) => {
   const url = new URL(fetchEvent.request.url)
-  if (url.protocol === 'chrome-extension:') {
+  if (url.origin === ownOrigin) {
     fetchEvent.respondWith(mapRequestsToLocalhost(url.href))
   }
 })


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When the SW re-routes requests from the CRX origin to the ViteDevServer, it calls `response.text()` and makes that text the body. This causes requests to fail for some types of files, like images. This PR passes the response body directly to the new response. It should be a little more efficient too!