### PR TITLE
feat: auto-copy manifest assets

### DIFF
--- a/src/node/plugin-fileWriter--events.ts
+++ b/src/node/plugin-fileWriter--events.ts
@@ -115,8 +115,11 @@ function startLogger(server: ViteDevServer) {
     // TODO: log runtime reload from crxHmrPayload$
 
     filesError$.subscribe(({ error }) => {
-      logger.error('error from file writer')
-      if (error) logger.error(error.message)
+      logger.error(colors.dim('error from file writer:'), { timestamp: true })
+      if (error) {
+        const message = error?.stack ?? error.message
+        logger.error(colors.red(message))
+      }
     }),
   ]
 


### PR DESCRIPTION
This PR improves the way RPCE handles manifest assets, e.g., icons. A missing manifest asset causes Chrome to disable the extension.

1. If the asset is missing from the bundle, it will load the asset from the file system.
2. If the asset is missing from the file system, it will throw an ENOENT error.

The error will prevent HMR from trying to do a runtime reload until a successful build occurs, which is a nice win for DX.