### PR TITLE
Use slash to guarantee support Windows

### DIFF
--- a/src/manifest-input/updateManifest.ts
+++ b/src/manifest-input/updateManifest.ts
@@ -1,4 +1,5 @@
 import { basename, relative } from 'path'
+import slash from 'slash'
 import { RollupOptions } from 'rollup'
 import { ManifestInputPluginCache } from '../plugin-options'
 import { cloneObject } from './cloneObject'
@@ -56,15 +57,16 @@ export function updateManifestV3(
       .map(convertMatchPatterns)
 
     const matches = Array.from(new Set(allMatches))
+    // Use slash to guarantee support Windows
     const resources = [
-      `${chunkFileNames
+      slash(`${chunkFileNames
         .split('/')
         .join('/')
         .replace('[format]', '*')
         .replace('[name]', '*')
-        .replace('[hash]', '*')}`,
+        .replace('[hash]', '*')}`),
       ...cache.contentScripts.map((x) =>
-        relative(cache.srcDir!, x),
+        slash(relative(cache.srcDir!, x)),
       ),
     ]
     


### PR DESCRIPTION
Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no, because in `npm run test` every test fails with this error: `TypeError: Jest: a transform must export a 'process' function.`. `npm install` doesn't work either, I needed to run `npm install --legacy-peer-deps` to successfully install the dependencies. I don't want to fix the jest config and package.json just for this little patch. Please run the tests yourself.

Eslint completed without error.

I did not include the output of prettier, because it changed other parts of the code.

Also I replicated your comment from the MV2 code path to describe what this fix does. (Use slash to guarantee support Windows)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

#293

### Description

This change guarantees that only posix style path separators are present in the web_accessible_resources section of the generated manifest.json file on Windows.